### PR TITLE
fixed attempt to strip tuples

### DIFF
--- a/clean_validator/__init__.py
+++ b/clean_validator/__init__.py
@@ -91,11 +91,14 @@ def valid_object(obs, types, name=None, ignore_missing=False):
         if isinstance(resp, (tuple, list, )):
             resp, msg = resp
         if not resp:
-            erros.append(
-                'invalid field %s:%s %s' % (
-                    '.'.join(name), obs, msg
-                ).strip()
-            )
+            if msg:
+                erros.append(msg)
+            else:
+                erros.append(
+                    'invalid field %s:%s %s' % (
+                        '.'.join(name), obs, msg
+                    ).strip()
+                )
     elif isinstance(types, (tuple, OR)):
         is_erro = True
         resps = []


### PR DESCRIPTION
When run software in dicts like bellow, occur an error occurs because software try to strip tuples

```
erros = clean_validator.valid_object(
    dict(email="teste@teste.com.br"),
    {
        'password': lambda c: (bool(len(c) > 3), 'Senha obrigatorio com mais de 3 caracteres'),
        'email': lambda c: (isinstance(c, str) and bool(c.strip()), 'Email obrigatorio'),
        'name': lambda c: (isinstance(c, str) and bool(c.strip()), 'Nome obrigatorio'),
    }
)
```