### PR TITLE
fixed attempt to len ints

### DIFF
--- a/clean_validator/__init__.py
+++ b/clean_validator/__init__.py
@@ -148,8 +148,8 @@ def valid_object(obs, types, name=None, ignore_missing=False):
             extras = set(obs) - set(types)
             missing = set(types) - set(obs)
         except:
-            extras = 0
-            missing = 0
+            extras = []
+            missing = []
             pass
         num_none = len([
             t


### PR DESCRIPTION
the created exception attributes 'ints' to variables 'extras' and 'missing'. In sequence code tries 'len' of this variables, but 'int' doesn't allow, generating error.